### PR TITLE
Return a floating point number in float h(vec2 uv)

### DIFF
--- a/shaders/Bump.frag
+++ b/shaders/Bump.frag
@@ -21,7 +21,7 @@ out vec4 out_color;
 
 float h(vec2 uv) {
   // You may want to use this helper function...
-  return 0;
+  return 0.0;
 }
 
 void main() {

--- a/shaders/Displacement.frag
+++ b/shaders/Displacement.frag
@@ -21,7 +21,7 @@ out vec4 out_color;
 
 float h(vec2 uv) {
   // You may want to use this helper function...
-  return 0;
+  return 0.0;
 }
 
 void main() {

--- a/shaders/Displacement.vert
+++ b/shaders/Displacement.vert
@@ -21,7 +21,7 @@ out vec4 v_tangent;
 
 float h(vec2 uv) {
   // You may want to use this helper function...
-  return 0;
+  return 0.0;
 }
 
 void main() {


### PR DESCRIPTION
This fixes the crash on my computer:
```
$ ./clothsim 
Loading files starting from: ..
Found shader file: Bump.frag
Error while compiling fragment shader "Bump":
#version 330

uniform vec3 u_cam_pos;
uniform vec3 u_light_pos;
uniform vec3 u_light_intensity;

uniform vec4 u_color;

uniform sampler2D u_texture_2;
uniform vec2 u_texture_2_size;

uniform float u_normal_scaling;
uniform float u_height_scaling;

in vec4 v_position;
in vec4 v_normal;
in vec4 v_tangent;
in vec2 v_uv;

out vec4 out_color;

float h(vec2 uv) {
  // You may want to use this helper function...
  return 0;
}

void main() {
  // YOUR CODE HERE
  
  // (Placeholder code. You will want to replace it.)
  out_color = (vec4(1, 1, 1, 0) + v_normal) / 2;
  out_color.a = 1;
}



Error: 
0:24(2): error: `return' with wrong type int, in function `h' returning float

terminate called after throwing an instance of 'std::runtime_error'
  what():  Shader compilation failed!
[1]    22382 abort (core dumped)  ./clothsim
```