### PR TITLE
fix severe memory leaks

### DIFF
--- a/src/clothSimulator.cpp
+++ b/src/clothSimulator.cpp
@@ -358,6 +358,8 @@ void ClothSimulator::drawWireframe(GLShader &shader) {
   //shader.uploadAttrib("in_normal", normals);
 
   shader.drawArray(GL_LINES, 0, num_springs * 2);
+
+  shader.freeAttrib("in_position");
 }
 
 void ClothSimulator::drawNormals(GLShader &shader) {
@@ -390,6 +392,9 @@ void ClothSimulator::drawNormals(GLShader &shader) {
   shader.uploadAttrib("in_normal", normals, false);
 
   shader.drawArray(GL_TRIANGLES, 0, num_tris * 3);
+
+  shader.freeAttrib("in_position");
+  shader.freeAttrib("in_normal");
 }
 
 void ClothSimulator::drawPhong(GLShader &shader) {
@@ -435,6 +440,11 @@ void ClothSimulator::drawPhong(GLShader &shader) {
   shader.uploadAttrib("in_tangent", tangents, false);
 
   shader.drawArray(GL_TRIANGLES, 0, num_tris * 3);
+
+  shader.freeAttrib("in_position");
+  shader.freeAttrib("in_normal");
+  shader.freeAttrib("in_uv");
+  shader.freeAttrib("in_tangent");
 }
 
 // ----------------------------------------------------------------------------

--- a/src/collision/plane.cpp
+++ b/src/collision/plane.cpp
@@ -47,4 +47,9 @@ void Plane::render(GLShader &shader) {
   }
 
   shader.drawArray(GL_TRIANGLE_STRIP, 0, 4);
+
+  shader.freeAttrib("in_position");
+  if (shader.attrib("in_normal", false) != -1) {
+    shader.freeAttrib("in_normal");
+  }
 }

--- a/src/misc/sphere_drawing.cpp
+++ b/src/misc/sphere_drawing.cpp
@@ -161,6 +161,17 @@ void SphereMesh::draw_sphere(GLShader &shader, const Vector3D &p, double r) {
   }
 
   shader.drawArray(GL_TRIANGLES, 0, sphere_num_indices);
+
+  shader.freeAttrib("in_position");
+  if (shader.attrib("in_normal", false) != -1) {
+    shader.freeAttrib("in_normal");
+  }
+  if (shader.attrib("in_uv", false) != -1) {
+    shader.freeAttrib("in_uv");
+  }
+  if (shader.attrib("in_tangent", false) != -1) {
+    shader.freeAttrib("in_tangent");
+  }
 }
 
 } // namespace Misc


### PR DESCRIPTION
The memory leaks happen when an attrib is uploaded to GLShader but is never freed. This can cause the program to eat up gigs of ram in seconds and freeze the kernel when rendering a high resolution sphere (and other primitives).

The bug can be reproduced by running `./clothsim -f ../scene/sphere.json -a 128 -o 128`.

Signed-off-by: Yuan Zhou <yvbbrjdr@berkeley.edu>